### PR TITLE
fix extra keys in CovReportTotals

### DIFF
--- a/hector/models.py
+++ b/hector/models.py
@@ -22,7 +22,11 @@ class CovReport:
 
     def __post_init__(self):
         if isinstance(self.totals, dict):
-            self.totals = CovReportTotals(**self.totals)
+            # Filter dict to only include fields defined in CovReportTotals
+            # This rejects extra keys like 'percent_statements_covered'
+            valid_fields = set(CovReportTotals.__dataclass_fields__.keys())
+            filtered_totals = {k: v for k, v in self.totals.items() if k in valid_fields}
+            self.totals = CovReportTotals(**filtered_totals)
 
     @property
     def overall_coverage(self):


### PR DESCRIPTION
Context -

We are generating coverage.json using coverage package and the [latest](https://pypi.org/project/coverage/7.12.0/) version (7.12.0), added new fields to the totals dictionary in coverage.json file (percent_statements_covered, percent_statements_covered_display) which is breaking the CovReportTotals dataclass. 


Error in pipeline - 

│ │        │   totals={                                                      │ │
│ │        │   │   'covered_lines': 1472,                                    │ │
│ │        │   │   'num_statements': 3192,                                   │ │
│ │        │   │   'percent_covered': 46.11528822055138,                     │ │
│ │        │   │   'percent_covered_display': '46',                          │ │
│ │        │   │   'missing_lines': 1720,                                    │ │
│ │        │   │   'excluded_lines': 5,                                      │ │
│ │        │   │   'percent_statements_covered': 46.11528822055138,          │ │
│ │        │   │   'percent_statements_covered_display': '46'                │ │
│ │        │   }                                                             │ │
│ │        )                                                                 │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────╯
TypeError: CovReportTotals.__init__() got an unexpected keyword argument 
'percent_statements_covered'



https://bitbucket.org/tata1mg/pharma_agg/pipelines/results/2054/steps/%7B2851cfcd-549b-49f8-938c-cfd76b8a94a8%7D


Testing
https://bitbucket.org/tata1mg/pharma_agg/pull-requests/742
https://bitbucket.org/tata1mg/merch_service/branch/PE-111

